### PR TITLE
Add Cursor support, auto-open .pftrace files, and build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Project infrastructure
 - Automate tests with ci.
 
+## [1.3.0] - 2026-03-21
+
+## Added
+- Cursor support
+- `*.pftrace` files now open in perfetto ui automatically.
+
 ## [1.2.0] - 2026-01-25
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Contributes following features to open a trace file in [perfetto ui](https://ui.
   - Opens pop up to select file to open & loads it in a new perfetto ui tab.
 - Explorer context menu item: `Open Trace For File`
   - Equivalent to `Open Trace For File` command but skips file selection steps.
+- Automatically open certain extensions in the perfetto ui
+  - Supported extensions: `.pftrace`
 - Configuration `perfetto-trace.path`
   - Customize perfetto ui url. Defaults to https://ui.perfetto.dev/.
 
@@ -26,6 +28,38 @@ The primary motivation is to automate the following remote profiling workflow:
 - copy trace file to local (scp or manual copy to local editor & save)
 - open [perfetto ui](https://ui.perfetto.dev/) in browser
 - open local trace file
+
+## Building from Source
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (v18+)
+- npm
+
+### Build & Package
+
+```bash
+npm install
+npx vsce package
+```
+
+This produces a `perfetto-trace-<version>.vsix` file.
+
+### Install
+
+**VS Code:**
+```bash
+code --install-extension perfetto-trace-*.vsix --force
+```
+
+**Cursor:**
+```bash
+cursor --install-extension perfetto-trace-*.vsix --force
+```
+
+Or use the Extensions sidebar: `...` menu > `Install from VSIX...`
+
+After installing, reload the window (`Ctrl+Shift+P` > `Developer: Reload Window`) — no full restart needed.
 
 ## Feature Proposals
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
-        "@types/vscode": "^1.99.0",
+        "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
         "@vscode/test-electron": "^2.5.2",
@@ -29,7 +29,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.99.0"
+        "vscode": "^1.74.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -523,7 +523,6 @@
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -926,7 +925,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1194,7 +1192,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1918,7 +1915,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4879,7 +4875,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5661,7 +5656,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5781,7 +5775,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -5831,7 +5824,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "publisher": "drain99",
   "preview": true,
   "engines": {
-    "vscode": "^1.99.0"
+    "vscode": "^1.74.0"
   },
   "categories": [
     "Visualization",
@@ -49,6 +49,18 @@
         }
       ]
     },
+    "customEditors": [
+      {
+        "viewType": "perfetto-trace.perfetto-native-editor",
+        "displayName": "Perfetto Trace Viewer",
+        "selector": [
+          {
+            "filenamePattern": "*.pftrace"
+          }
+        ],
+        "priority": "default"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Perfetto Trace",
@@ -76,7 +88,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
-    "@types/vscode": "^1.99.0",
+    "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "@vscode/test-electron": "^2.5.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,18 @@ import { PerfettoDocument } from './perfettoDocument';
 export function activate(context: vscode.ExtensionContext): void {
 	const provider = new PerfettoEditorProvider(context);
 
+	// Register custom editor for .pftrace files
+	context.subscriptions.push(
+		vscode.window.registerCustomEditorProvider(
+			EditorViewTypes.PerfettoNativeEditor,
+			provider,
+			{
+				supportsMultipleEditorsPerDocument: false,
+				webviewOptions: { retainContextWhenHidden: true }
+			}
+		)
+	);
+
 	// Register all commands
 	context.subscriptions.push(
 		vscode.commands.registerCommand(

--- a/test-workspace/trace2.pftrace
+++ b/test-workspace/trace2.pftrace
@@ -1,0 +1,46 @@
+{
+  "traceEvents": [
+    {
+      "name": "main",
+      "ph": "B",
+      "ts": 1000,
+      "pid": 1,
+      "tid": 1
+    },
+    {
+      "name": "functionA",
+      "ph": "B",
+      "ts": 1100,
+      "pid": 1,
+      "tid": 1
+    },
+    {
+      "name": "functionB",
+      "ph": "B",
+      "ts": 1200,
+      "pid": 1,
+      "tid": 1
+    },
+    {
+      "name": "functionB",
+      "ph": "E",
+      "ts": 1300,
+      "pid": 1,
+      "tid": 1
+    },
+    {
+      "name": "functionA",
+      "ph": "E",
+      "ts": 1400,
+      "pid": 1,
+      "tid": 1
+    },
+    {
+      "name": "main",
+      "ph": "E",
+      "ts": 1500,
+      "pid": 1,
+      "tid": 1
+    }
+  ]
+}


### PR DESCRIPTION
- Lower engines.vscode from ^1.99.0 to ^1.74.0 for Cursor compatibility
- Lower @types/vscode to match
- Register customEditor for *.pftrace files so they open in Perfetto viewer automatically
- Set retainContextWhenHidden on the custom editor to prevent resets on tab switch
- Add deploy/deploy:cursor convenience scripts
- Add build-from-source instructions to README